### PR TITLE
Update S_USER_PAPERDOLL_INFO

### DIFF
--- a/protocol/S_USER_PAPERDOLL_INFO.6.def
+++ b/protocol/S_USER_PAPERDOLL_INFO.6.def
@@ -1,0 +1,133 @@
+uint32 templateId
+uint64 gameId
+uint32 serverId # playerId if same server?
+uint32 playerId # 0 if same server?
+uint32 walkMoveSpeed
+uint16 level
+uint16 gatherMineral
+uint16 gatherBug
+uint16 gatherHerb
+uint16 gatherEnergy
+uint16 homunculusSkillLevel
+int64  totalXp
+int64  levelXp
+int64  nextLevelXp
+uint32 talentLevel
+uint64 talentXp
+uint32 talentDailyXp
+uint32 weapon
+uint32 body
+uint32 hand
+uint32 feet
+uint32 underwear
+uint32 head
+uint32 face
+int32  power
+int32  endurance
+int32  impactFactor
+int32  balanceFactor
+int16  moveSpeed
+int16  attackSpeed
+float  critRate
+float  critResist
+float  critPower
+int32  attack
+int32  attack2
+int32  defense
+int32  impact
+int32  balance
+float  resistWeakening
+float  resistPeriodic
+float  resistStun
+int32  powerBonus
+int32  enduranceBonus
+int32  impactFactorBonus
+int32  balanceFactorBonus
+int16  moveSpeedBonus
+int16  attackSpeedBonus
+float  critRateBonus
+float  critResistBonus
+float  critPowerBonus
+int32  attackBonus
+int32  attack2Bonus
+int32  defenseBonus
+int32  impactBonus
+int32  balanceBonus
+float  resistWeakeningBonus
+float  resistPeriodicBonus
+float  resistStunBonus
+int16  vitality # ?
+int32  condition
+int32  conditionMax
+int32  itemLevelInventory
+int32  itemLevel
+uint32 infamy
+uint32 styleHead
+uint32 styleFace
+uint32 styleBack
+uint32 styleWeapon
+uint32 styleBody
+uint32 styleFootprint
+uint32 flightDataId
+float  flightSpeedMultiplier
+
+array items
+- int32  id
+- uint64 dbid
+- uint64 ownerId # playerId
+- uint32 slot # 0-39 are reserved for equipment:
+              # 1 = Weapon, 3 = Body, 4 = Hands, 5 = Feet, 6 = Left Earring, 7 = Right Earring, 8 = Left Ring, 9 = Right Ring,
+              # 10 = Necklace, 11 = Underwear, 12 = Head, 13 = Face, 14 = Costume Head, 15 = Costume Face, 16 = Costume Weapon,
+              # 17 = Costume Body, 18 = Costume Back, 19 = Belt, 20 = Brooch, 21 = Footprints
+- int32  storageType # Not read by the client, always 0 for inventory
+- int32  amount
+- int32  enchant
+- int32  durability # only used for homunculi
+- bool   soulbound
+- int32  crystal1 # The client ignores empty slots, so (crystal1, <empty>, crystal3) will become (crystal1, crystal3, <empty>).
+- int32  crystal2 # All crystals will be displayed in the tooltip (if the item supports crystals), however only the maximum
+- int32  crystal3 # number of crystals that the item supports will be displayed in the equipment window.
+- int32  crystal4
+- int32  crystal5
+- int32  passivitySet
+- int32  extraPassivitySets
+- int32  remodel
+- uint32 dye
+- int32  dyeSecRemaining # -1 = unlimited
+- int64  dyeDate # not read by the client
+- int64  dyeExpiryDate
+- bool   masterwork
+- int32  enigma
+- int32  timesBrokered
+- int32  enchantAdvantage # % x 100
+- int32  enchantBonus # % x 100 (added to enchantAdvantage + displayed separately)
+- int32  enchantBonusMaxPlus
+- uint64 boundToPlayer # playerId
+- bool   awakened
+- int32  liberationStatus # how often this item was liberated
+- int32  feedstock
+- int32  boundToItem
+- bool   hasEtching
+- bool   pcbang
+- int64  xp
+- array  passivitySets
+- - uint32 index
+- - int32  masterworkBonus
+- - int32  itemLevel
+- - int32  minItemLevel
+- - int32  maxItemLevel
+- - array  passivities
+- - - int32 id
+
+array  instances
+- int32 id
+- int32 unk # HH phase maybe?
+- int32 cooldown
+- int16 entries
+
+array  unkArray
+
+string name
+string status
+string guild
+string guildRank


### PR DESCRIPTION
Added version 6 of the definition for S_USER_PAPERDOLL_INFO.
Updated some of the unknown character status and item fields (item stuff was really broken in version 5).

The definition file has been tested and outputs the correct data for character stats, equipped items, instances and strings.